### PR TITLE
feat(tasks): all priorities always visible

### DIFF
--- a/frontend/src/components/misc/Icon.ts
+++ b/frontend/src/components/misc/Icon.ts
@@ -13,6 +13,7 @@ import {
 	faBars,
 	faBell,
 	faBolt,
+	faBomb,
 	faCalendar,
 	faCheck,
 	faCheckDouble,
@@ -29,6 +30,7 @@ import {
 	faEllipsisH,
 	faEllipsisV,
 	faExclamationCircle,
+	faExclamationTriangle,
 	faEye,
 	faEyeSlash,
 	faFile,
@@ -42,6 +44,7 @@ import {
 	faImage,
 	faKeyboard,
 	faLayerGroup,
+	faLightbulb,
 	faList,
 	faListOl,
 	faLock,
@@ -193,6 +196,10 @@ library.add(faFont)
 library.add(faRulerHorizontal)
 library.add(faUnderline)
 library.add(faFaceLaugh)
+library.add(faBomb)
+library.add(faExclamationTriangle)
+library.add(faLightbulb)
+library.add(faBolt)
 
 // overwriting the wrong types
 export default FontAwesomeIcon as unknown as FontAwesomeIconFixedTypes

--- a/frontend/src/components/tasks/partials/PriorityLabel.vue
+++ b/frontend/src/components/tasks/partials/PriorityLabel.vue
@@ -1,17 +1,36 @@
 <template>
 	<span
-		v-if="!done && (showAll || priority >= priorities.HIGH)"
+		v-if="!done && (showAll || priority >= priorities.LOW)"
 		:class="{
-			'not-so-high': priority === priorities.HIGH,
+			'not-so-high': priority > priorities.LOW && priority < priorities.HIGH,
 			'high-priority': priority >= priorities.HIGH
 		}"
 		class="priority-label"
 	>
 		<span
-			v-if="priority >= priorities.HIGH"
+			v-if="priority >= priorities.LOW"
 			class="icon"
 		>
-			<Icon icon="exclamation-circle" />
+			<Icon
+				v-if="priority === priorities.LOW"
+				icon="lightbulb"
+			/>
+			<Icon
+				v-if="priority === priorities.MEDIUM"
+				icon="bolt"
+			/>
+			<Icon
+				v-if="priority === priorities.HIGH"
+				icon="exclamation-circle"
+			/>
+			<Icon
+				v-if="priority === priorities.URGENT"
+				icon="exclamation-triangle"
+			/>
+			<Icon
+				v-if="priority === priorities.DO_NOW"
+				icon="bomb"
+			/>
 		</span>
 		<span>
 			<template v-if="priority === priorities.UNSET">{{ $t('task.priority.unset') }}</template>


### PR DESCRIPTION
All the 5 priority levels (`low`, `medium`, `high`, `urgent`, `do now`) are now always visible on the task (if it is not marked as `done`).